### PR TITLE
Add basic version of target tracker class

### DIFF
--- a/tests/target_tracker_tests.py
+++ b/tests/target_tracker_tests.py
@@ -1,0 +1,64 @@
+import unittest
+from uavf_2024.imaging.target_tracker import TargetTracker
+from uavf_2024.imaging.imaging_types import FullPrediction, TargetDescription, Target3D
+import numpy as np
+
+class TestImagingFrontend(unittest.TestCase):
+    def test_with_certain_match(self):
+        tracker = TargetTracker()
+        
+        target_1 = Target3D(
+                12.34,
+                69.420,
+                np.eye(13)[1],
+                np.eye(35)[3],
+                np.eye(8)[3],
+                np.eye(8)[7],
+            )
+        
+        target_2 = Target3D(
+                12.34,
+                69.420,
+                np.eye(13)[2],
+                np.eye(35)[2],
+                np.eye(8)[2],
+                np.eye(8)[2],
+            )
+
+        # violating private-ness for testing
+        tracker._targets = [
+           target_1, target_2 
+        ]
+
+        desc = TargetDescription(1,3,3,7)
+        assert tracker.closest_match(desc) is target_1
+
+    def test_with_near_match(self):
+        tracker = TargetTracker()
+        
+        target_1 = Target3D(
+                12.34,
+                69.420,
+                np.eye(13)[1],
+                np.eye(35)[3],
+                np.eye(8)[3],
+                np.eye(8)[7],
+            )
+        
+        target_2 = Target3D(
+                12.34,
+                69.420,
+                np.eye(13)[2],
+                np.eye(35)[2],
+                np.eye(8)[2],
+                np.eye(8)[2],
+            )
+
+        # violating private-ness for testing
+        tracker._targets = [
+           target_1, target_2 
+        ]
+
+        desc = TargetDescription(2,2,2,7)
+        assert tracker.closest_match(desc) is target_2
+

--- a/uavf_2024/imaging/imaging_types.py
+++ b/uavf_2024/imaging/imaging_types.py
@@ -30,3 +30,23 @@ class InstanceSegmentationResult:
     confidences: np.ndarray
     mask: np.ndarray
     img: np.ndarray
+
+@dataclass
+class TargetDescription:
+    shape: int
+    letter: int
+    shape_color: int
+    letter_color: int
+
+@dataclass
+class Target3D:
+    '''
+    TODO: decision to use lat/lng is not final
+    We might also want to incorporate information about the distance from which we've seen this target. Like, if we've only seen it from far away, and we get a new classification from a closer image, it should have more weight.
+    '''
+    lat: float
+    lng: float
+    shape_probs: np.ndarray
+    letter_probs: np.ndarray
+    shape_col_probs: np.ndarray
+    letter_col_probs: np.ndarray

--- a/uavf_2024/imaging/target_tracker.py
+++ b/uavf_2024/imaging/target_tracker.py
@@ -5,7 +5,7 @@ import numpy as np
 
 class TargetTracker:
     def __init__(self):
-        self.targets: list[Target3D] = []
+        self._targets: list[Target3D] = []
 
     def update_with_new_data(self, new_preds: list[tuple[FullPrediction,np.ndarray]]):
         '''
@@ -25,9 +25,9 @@ class TargetTracker:
         Finds closest tracked target to the description using the class probabilities.
         Multiplies together P(class==target_class) for all 4 labels, which should be the mathematically correct way to do this, since desc==target_desc means shape_class==target_shape_class AND letter_class==target_letter_class AND ... etc.
         '''
-        best_match, best_score = self.targets[0], 0
+        best_match, best_score = self._targets[0], 0
 
-        for target in self.targets:
+        for target in self._targets:
             shape_score = target.shape_probs[target_desc.shape]
             letter_score = target.letter_probs[target_desc.letter]
             shape_color_score = target.shape_col_probs[target_desc.shape_color]
@@ -39,3 +39,6 @@ class TargetTracker:
                 best_score = new_score
 
         return best_match
+
+    def get_all_targets(self):
+        return self._targets

--- a/uavf_2024/imaging/target_tracker.py
+++ b/uavf_2024/imaging/target_tracker.py
@@ -1,0 +1,41 @@
+from .imaging_types import FullPrediction, Target3D, TargetDescription
+from dataclasses import dataclass
+import numpy as np
+
+
+class TargetTracker:
+    def __init__(self):
+        self.targets: list[Target3D] = []
+
+    def update_with_new_data(self, new_preds: list[tuple[FullPrediction,np.ndarray]]):
+        '''
+            new_preds should look like this:
+            [
+                (prediction1, camera_pose1),
+                (prediction2, camera_pose2)
+                ... etc ...
+            ]
+            TODO: figure out format for camera pose, and update the Target3D class with our final decision for how to define a global position
+        
+        '''
+        raise NotImplementedError()
+
+    def closest_match(self, target_desc: TargetDescription) -> Target3D:
+        '''
+        Finds closest tracked target to the description using the class probabilities.
+        Multiplies together P(class==target_class) for all 4 labels, which should be the mathematically correct way to do this, since desc==target_desc means shape_class==target_shape_class AND letter_class==target_letter_class AND ... etc.
+        '''
+        best_match, best_score = self.targets[0], 0
+
+        for target in self.targets:
+            shape_score = target.shape_probs[target_desc.shape]
+            letter_score = target.letter_probs[target_desc.letter]
+            shape_color_score = target.shape_col_probs[target_desc.shape_color]
+            letter_color_score = target.letter_col_probs[target_desc.letter_color]
+
+            new_score = shape_score * letter_score * shape_color_score * letter_color_score
+            if new_score > best_score:
+                best_match = target
+                best_score = new_score
+
+        return best_match

--- a/uavf_2024/imaging/target_tracker.py
+++ b/uavf_2024/imaging/target_tracker.py
@@ -1,5 +1,5 @@
 from .imaging_types import FullPrediction, Target3D, TargetDescription
-from dataclasses import dataclass
+from .utils import calc_match_score
 import numpy as np
 
 
@@ -28,12 +28,7 @@ class TargetTracker:
         best_match, best_score = self._targets[0], 0
 
         for target in self._targets:
-            shape_score = target.shape_probs[target_desc.shape]
-            letter_score = target.letter_probs[target_desc.letter]
-            shape_color_score = target.shape_col_probs[target_desc.shape_color]
-            letter_color_score = target.letter_col_probs[target_desc.letter_color]
-
-            new_score = shape_score * letter_score * shape_color_score * letter_color_score
+            new_score = calc_match_score(target_desc, target)
             if new_score > best_score:
                 best_match = target
                 best_score = new_score

--- a/uavf_2024/imaging/utils.py
+++ b/uavf_2024/imaging/utils.py
@@ -1,0 +1,8 @@
+from .imaging_types import TargetDescription, Target3D
+def calc_match_score(target_desc: TargetDescription, target: Target3D):
+        shape_score = target.shape_probs[target_desc.shape]
+        letter_score = target.letter_probs[target_desc.letter]
+        shape_color_score = target.shape_col_probs[target_desc.shape_color]
+        letter_color_score = target.letter_col_probs[target_desc.letter_color]
+
+        return shape_score * letter_score * shape_color_score * letter_color_score


### PR DESCRIPTION
Putting this up so we have the types we want defined and a place to put the relevant code for future tasks. How I think this should work is, the new class will only be responsible for the public methods defined right now, and if we want more functionality, we just compose it with other classes.

Added two tests. One of them fails right now because is any of the labels is a 0 confidence for the ground-truth, the entire closeness score goes to zero, which we should probably change so all 0's get set to a small number instead so there's a way to break ties between matches that have one of the labels 0% matching, but that can be a future task (#18)