### PR TITLE
Extract tiler and add overlap

### DIFF
--- a/tests/imaging_utils_tests.py
+++ b/tests/imaging_utils_tests.py
@@ -1,5 +1,6 @@
 import unittest
 import numpy as np
+from itertools import pairwise
 
 from uavf_2024.imaging.utils import generate_tiles
 
@@ -48,3 +49,35 @@ class ImagingUtilsTest(unittest.TestCase):
                 
             # Check that all values in the image were covered by the tiles
             self.assertEqual(len(all_values), 0)
+
+    def test_uniform_spacing(self):
+        def test_with_params(width,height,tile_size,overlap):
+            img = np.zeros([width,height,3])
+            tile_size = 15
+            overlap  = 5
+            
+            x_coords = set() 
+            y_coords = set() 
+            for tile in generate_tiles(img, tile_size, overlap):
+                x_coords.add(tile.x)
+                y_coords.add(tile.y)
+
+            diffs_x = set()
+            diffs_y = set()
+            for x1, x2 in pairwise(sorted(x_coords)):
+                diffs_x.add(x2-x1)
+
+            for y1, y2 in pairwise(sorted(y_coords)):
+                diffs_y.add(y2-y1)
+            
+            self.assertLessEqual(len(diffs_x), 2)
+            self.assertLessEqual(len(diffs_y), 2)
+
+            self.assertLessEqual(max(diffs_x)-min(diffs_x), 1)
+            self.assertLessEqual(max(diffs_y)-min(diffs_y), 1)
+
+        for i in range(64, 128, 7):
+            for j in range(64, 128, 4):
+                tile_size = np.random.randint(5,30)
+                test_with_params(i,j,tile_size,np.random.randint(0,tile_size))
+

--- a/tests/imaging_utils_tests.py
+++ b/tests/imaging_utils_tests.py
@@ -1,0 +1,50 @@
+import unittest
+import numpy as np
+
+from uavf_2024.imaging.utils import generate_tiles
+
+class ImagingUtilsTest(unittest.TestCase):
+    def test_simple_tiling(self):
+        """
+        Tests simple, no-overlap tiling.
+        """
+        
+        test_dims = (4000, 4000, 3)
+        img = np.arange(test_dims[0] * test_dims[1] * test_dims[2], dtype=np.uint8).reshape(test_dims)
+        tile_size = 500
+        
+        # Test that the generator yields the correct number of tiles of the correct shape
+        tile_count = 0
+        for tile in generate_tiles(img, tile_size, 0):
+            # Check that the tile is the correct shape
+            self.assertEqual(tile.img.shape, (tile_size, tile_size, 3))
+            tile_count += 1
+
+        self.assertEqual(tile_count, 4000 // 500 * 4000 // 500)
+        
+    def test_overlap_tiling(self):
+        """
+        Tests tiling with overlap.
+        Checks that tiles are the correct shape and that they cover the entire image.
+        Does NOT check that the overlap is correct.
+        """
+        for length in range(50, 55):
+            test_dims = (length, length, 3)
+            img_values = np.arange(test_dims[0] * test_dims[1] * test_dims[2])
+            img = img_values.reshape(test_dims)
+            all_values = set(img_values)
+            
+            tile_size = 10
+            tiles = [tile for tile in generate_tiles(img, tile_size, 1)]
+            
+            self.assertEqual(len(tiles), 36)
+            
+            for tile in tiles:
+                # Check that the tile is the correct shape
+                self.assertEqual(tile.img.shape, (tile_size, tile_size, 3))
+                    
+                # Remove from the set of values in the image the values in the tile
+                all_values -= set(tile.img.flatten())
+                
+            # Check that all values in the image were covered by the tiles
+            self.assertEqual(len(all_values), 0)

--- a/uavf_2024/imaging/image_processor.py
+++ b/uavf_2024/imaging/image_processor.py
@@ -20,7 +20,7 @@ class ImageProcessor:
 
     def process_image(self, img: np.ndarray) -> "list[FullPrediction]":
         '''
-        img shape should be (channels, width, height)
+        img shape should be (height, width, channels)
         (that tuple order is a placeholder for now and we can change it later, but it should be consistent and we need to keep the docstring updated)
         '''
 

--- a/uavf_2024/imaging/image_processor.py
+++ b/uavf_2024/imaging/image_processor.py
@@ -1,5 +1,4 @@
 import numpy as np
-from dataclasses import dataclass
 
 from uavf_2024.imaging.utils import generate_tiles
 from .imaging_types import FullPrediction,InstanceSegmentationResult
@@ -7,12 +6,6 @@ from .letter_classification import LetterClassifier
 from .shape_detection import ShapeInstanceSegmenter
 from .color_segmentation import color_segmentation
 from .color_classification import ColorClassifier
-
-@dataclass
-class Tile:
-    img: np.ndarray
-    x: int
-    y: int
 
 class ImageProcessor:
     def __init__(self):

--- a/uavf_2024/imaging/image_processor.py
+++ b/uavf_2024/imaging/image_processor.py
@@ -1,12 +1,12 @@
 import numpy as np
 from dataclasses import dataclass
-import math
+
+from uavf_2024.imaging.utils import split_to_tiles
 from .imaging_types import FullPrediction,InstanceSegmentationResult
 from .letter_classification import LetterClassifier
 from .shape_detection import ShapeInstanceSegmenter
 from .color_segmentation import color_segmentation
 from .color_classification import ColorClassifier
-import itertools
 
 @dataclass
 class Tile:
@@ -25,28 +25,13 @@ class ImageProcessor:
         self.letter_classifier = LetterClassifier(self.letter_size)
         self.color_classifier = ColorClassifier()
 
-    def _split_to_tiles(self, img: np.ndarray) -> list[Tile]:
-        h, w = img.shape[:2]
-        n_horizontal_tiles = math.ceil(w / self.tile_size)
-        n_vertical_tiles = math.ceil(h / self.tile_size)
-        all_tiles: list[Tile] = []
-        v_indices = np.linspace(0, h - self.tile_size, n_vertical_tiles).astype(int)
-        h_indices = np.linspace(0, w - self.tile_size, n_horizontal_tiles).astype(int)
-
-        for v, h in itertools.product(v_indices, h_indices):
-            tile = img[v:v + self.tile_size, h:h + self.tile_size]
-            all_tiles.append(Tile(tile, h, v))
-
-        return all_tiles
-
-    def process_image(self, img: np.ndarray) -> list[FullPrediction]:
+    def process_image(self, img: np.ndarray) -> "list[FullPrediction]":
         '''
         img shape should be (channels, width, height)
         (that tuple order is a placeholder for now and we can change it later, but it should be consistent and we need to keep the docstring updated)
-
         '''
 
-        tiles = self._split_to_tiles(img)
+        tiles = split_to_tiles(img, self.tile_size)
 
         shape_results: list[InstanceSegmentationResult] = []
 

--- a/uavf_2024/imaging/image_processor.py
+++ b/uavf_2024/imaging/image_processor.py
@@ -1,7 +1,7 @@
 import numpy as np
 from dataclasses import dataclass
 
-from uavf_2024.imaging.utils import split_to_tiles
+from uavf_2024.imaging.utils import generate_tiles
 from .imaging_types import FullPrediction,InstanceSegmentationResult
 from .letter_classification import LetterClassifier
 from .shape_detection import ShapeInstanceSegmenter
@@ -31,7 +31,7 @@ class ImageProcessor:
         (that tuple order is a placeholder for now and we can change it later, but it should be consistent and we need to keep the docstring updated)
         '''
 
-        tiles = split_to_tiles(img, self.tile_size)
+        tiles = generate_tiles(img, self.tile_size)
 
         shape_results: list[InstanceSegmentationResult] = []
 

--- a/uavf_2024/imaging/imaging_types.py
+++ b/uavf_2024/imaging/imaging_types.py
@@ -1,6 +1,11 @@
 from dataclasses import dataclass
-from enum import Enum
 import numpy as np
+
+@dataclass
+class Tile:
+    img: np.ndarray
+    x: int
+    y: int
 
 @dataclass
 class FullPrediction:

--- a/uavf_2024/imaging/utils.py
+++ b/uavf_2024/imaging/utils.py
@@ -24,7 +24,7 @@ def generate_tiles(img: np.ndarray, tile_size: int, min_overlap: int = 0) -> "Ge
     IMO, it's not good practice to have a utils module, especially considering this function only has one caller.
 
     Args:
-        img (np.ndarray): Color, full-resolution input image in the format (channels, height, width)
+        img (np.ndarray): Color, full-resolution input image in the format (height, width, channels)
         tile_size (int): Width/height of each tile
         min_overlap (int, optional): Number of pixels that each tile overlaps with its neighbors. Defaults to 0.
 
@@ -32,7 +32,7 @@ def generate_tiles(img: np.ndarray, tile_size: int, min_overlap: int = 0) -> "Ge
         Generator[Tile, None, None]: Generator that yields each tile
     """
     
-    img_height, img_width = img.shape[1:]
+    img_height, img_width = img.shape[:2]
     
     if tile_size > img_width or tile_size > img_height:
         raise ValueError("tile dimensions cannot be larger than origin dimensions")
@@ -57,7 +57,7 @@ def generate_tiles(img: np.ndarray, tile_size: int, min_overlap: int = 0) -> "Ge
         for vertical_index in range(y_count):
             # Converting back to int because its expected downstream
             # All dimensions should be refactored to use unit16
-            yield Tile(img[:, y:y+tile_size, x:x+tile_size], int(x), int(y))
+            yield Tile(img[y:y+tile_size, x:x+tile_size], int(x), int(y))
             if vertical_index < (y_count-1):
                 y = y + tile_size - remaindersY[vertical_index]
         if horizontal_index < (x_count-1):

--- a/uavf_2024/imaging/utils.py
+++ b/uavf_2024/imaging/utils.py
@@ -1,5 +1,3 @@
-import itertools
-import math
 from typing import Generator
 
 import numpy as np
@@ -16,13 +14,52 @@ def calc_match_score(target_desc: TargetDescription, target: Target3D):
     return shape_score * letter_score * shape_color_score * letter_color_score
 
 
-def generate_tiles(img: np.ndarray, tile_size: int) -> "Generator[Tile, None, None]":
-    h, w = img.shape[:2]
-    n_horizontal_tiles = math.ceil(w / tile_size)
-    n_vertical_tiles = math.ceil(h / tile_size)
-    v_indices = np.linspace(0, h - tile_size, n_vertical_tiles).astype(int)
-    h_indices = np.linspace(0, w - tile_size, n_horizontal_tiles).astype(int)
+def generate_tiles(img: np.ndarray, tile_size: int, min_overlap: int = 0) -> "Generator[Tile, None, None]":
+    """
+    Split high resolution input image into number of fixed-dimension, squares tiles, 
+    ensuring that each tile overlaps with its neighbors by at least `min_overlap` pixels.
+    
+    @read: https://stackoverflow.com/questions/58383814/how-to-divide-an-image-into-evenly-sized-overlapping-if-needed-tiles
 
-    for v, h in itertools.product(v_indices, h_indices):
-        tile = img[v : v + tile_size, h : h + tile_size]
-        yield tile
+    IMO, it's not good practice to have a utils module, especially considering this function only has one caller.
+
+    Args:
+        img (np.ndarray): Color, full-resolution input image in the format (channels, height, width)
+        tile_size (int): Width/height of each tile
+        min_overlap (int, optional): Number of pixels that each tile overlaps with its neighbors. Defaults to 0.
+
+    Yields:
+        Generator[Tile, None, None]: Generator that yields each tile
+    """
+    
+    img_height, img_width = img.shape[1:]
+    
+    if tile_size > img_width or tile_size > img_height:
+        raise ValueError("tile dimensions cannot be larger than origin dimensions")
+
+    # Number of tiles in each dimension
+    x_count = np.uint8(np.ceil(img_width / tile_size))
+    y_count = np.uint8(np.ceil(img_height / tile_size))
+
+    # Total remainders
+    overflow_x = x_count * tile_size - img_width
+    overflow_y = y_count * tile_size - img_height
+
+    # Set up remainders per tile
+    remaindersX = np.ones((x_count-1,), dtype=np.uint8) * np.uint16(np.floor(overflow_x / (x_count-1)))
+    remaindersY = np.ones((y_count-1,), dtype=np.uint8) * np.uint16(np.floor(overflow_y / (y_count-1)))
+    remaindersX[0:np.remainder(overflow_x, np.uint16(x_count-1))] += 1
+    remaindersY[0:np.remainder(overflow_y, np.uint16(y_count-1))] += 1
+    
+    x = np.uint16(0)
+    for horizontal_index in range(x_count):
+        y = np.uint16(0)
+        for vertical_index in range(y_count):
+            # Converting back to int because its expected downstream
+            # All dimensions should be refactored to use unit16
+            yield Tile(img[:, y:y+tile_size, x:x+tile_size], int(x), int(y))
+            if vertical_index < (y_count-1):
+                y = y + tile_size - remaindersY[vertical_index]
+        if horizontal_index < (x_count-1):
+            x = x + tile_size - remaindersX[horizontal_index]
+    

--- a/uavf_2024/imaging/utils.py
+++ b/uavf_2024/imaging/utils.py
@@ -1,5 +1,6 @@
 import itertools
 import math
+from typing import Generator
 
 import numpy as np
 
@@ -16,16 +17,13 @@ def calc_match_score(target_desc: TargetDescription, target: Target3D):
     return shape_score * letter_score * shape_color_score * letter_color_score
 
 
-def split_to_tiles(img: np.ndarray, tile_size: int) -> "list[Tile]":
+def generate_tiles(img: np.ndarray, tile_size: int) -> "Generator[Tile, None, None]":
     h, w = img.shape[:2]
     n_horizontal_tiles = math.ceil(w / tile_size)
     n_vertical_tiles = math.ceil(h / tile_size)
-    all_tiles: list[Tile] = []
     v_indices = np.linspace(0, h - tile_size, n_vertical_tiles).astype(int)
     h_indices = np.linspace(0, w - tile_size, n_horizontal_tiles).astype(int)
 
     for v, h in itertools.product(v_indices, h_indices):
         tile = img[v : v + tile_size, h : h + tile_size]
-        all_tiles.append(Tile(tile, h, v))
-
-    return all_tiles
+        yield tile

--- a/uavf_2024/imaging/utils.py
+++ b/uavf_2024/imaging/utils.py
@@ -1,8 +1,31 @@
-from .imaging_types import TargetDescription, Target3D
-def calc_match_score(target_desc: TargetDescription, target: Target3D):
-        shape_score = target.shape_probs[target_desc.shape]
-        letter_score = target.letter_probs[target_desc.letter]
-        shape_color_score = target.shape_col_probs[target_desc.shape_color]
-        letter_color_score = target.letter_col_probs[target_desc.letter_color]
+import itertools
+import math
 
-        return shape_score * letter_score * shape_color_score * letter_color_score
+import numpy as np
+
+from uavf_2024.imaging.image_processor import Tile
+from .imaging_types import TargetDescription, Target3D
+
+
+def calc_match_score(target_desc: TargetDescription, target: Target3D):
+    shape_score = target.shape_probs[target_desc.shape]
+    letter_score = target.letter_probs[target_desc.letter]
+    shape_color_score = target.shape_col_probs[target_desc.shape_color]
+    letter_color_score = target.letter_col_probs[target_desc.letter_color]
+
+    return shape_score * letter_score * shape_color_score * letter_color_score
+
+
+def split_to_tiles(img: np.ndarray, tile_size: int) -> "list[Tile]":
+    h, w = img.shape[:2]
+    n_horizontal_tiles = math.ceil(w / tile_size)
+    n_vertical_tiles = math.ceil(h / tile_size)
+    all_tiles: list[Tile] = []
+    v_indices = np.linspace(0, h - tile_size, n_vertical_tiles).astype(int)
+    h_indices = np.linspace(0, w - tile_size, n_horizontal_tiles).astype(int)
+
+    for v, h in itertools.product(v_indices, h_indices):
+        tile = img[v : v + tile_size, h : h + tile_size]
+        all_tiles.append(Tile(tile, h, v))
+
+    return all_tiles

--- a/uavf_2024/imaging/utils.py
+++ b/uavf_2024/imaging/utils.py
@@ -4,8 +4,7 @@ from typing import Generator
 
 import numpy as np
 
-from uavf_2024.imaging.image_processor import Tile
-from .imaging_types import TargetDescription, Target3D
+from .imaging_types import TargetDescription, Target3D, Tile
 
 
 def calc_match_score(target_desc: TargetDescription, target: Target3D):


### PR DESCRIPTION
## Description

Extracts the tiling functionality from `ImageProcessor` to `utils.py` and adds a parameterizes overlap in the tiling calculus, as stated in #10. 

I don't think that it's a good idea to put it in the `utils` module (or to have a `utils` module at all) because it only has one caller. In my opinion, it should reside in `image_processor.py` if it only has one caller and a more descriptive module like `image_transformers` if it has multiple callers.

__NOTE: I haven't been able to fully test this PR because the python version installed in the given docker is 3.8.10, which doesn't support which doesn't support type subscripts in function declarations and throws a TypeError.__

## Testing
Fails the same test as main 👍

Added basic tests to check overlapping tiling

## Issues
Closes #10 