### PR TITLE
Simplify Dev Container Setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,6 +3,7 @@ FROM ros:humble
 RUN apt update
 RUN apt-get update --fix-missing
 RUN apt-get install -y python3-pip
+RUN apt-get install -y ffmpeg libsm6 libxext6
 # RUN apt install -y curl
 # RUN apt-get install -y wget
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,5 +13,8 @@ RUN apt-get install -y ffmpeg libsm6 libxext6
 # WORKDIR "/home/ws/PX4-Autopilot"
 # RUN Tools/setup/ubuntu.sh
 # RUN make px4_sitl
+WORKDIR "/home/ws/uavf_2024"
+COPY setup.py setup.py
+RUN pip install -e .
 
 CMD ["/bin/bash"]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,16 +1,16 @@
-FROM ros:foxy
+FROM ros:humble
 
 RUN apt update
 RUN apt-get update --fix-missing
-RUN apt install -y curl
 RUN apt-get install -y python3-pip
-RUN apt-get install -y wget
+# RUN apt install -y curl
+# RUN apt-get install -y wget
 
-RUN git clone --recursive https://github.com/PX4/PX4-Autopilot.git /home/ws/PX4-Autopilot
-RUN curl -sSL http://get.gazebosim.org | sh
+# RUN git clone --recursive https://github.com/PX4/PX4-Autopilot.git /home/ws/PX4-Autopilot
+# RUN curl -sSL http://get.gazebosim.org | sh
 
-WORKDIR "/home/ws/PX4-Autopilot"
-RUN Tools/setup/ubuntu.sh
-RUN make px4_sitl
+# WORKDIR "/home/ws/PX4-Autopilot"
+# RUN Tools/setup/ubuntu.sh
+# RUN make px4_sitl
 
 CMD ["/bin/bash"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,13 +1,6 @@
 {
     "name": "UAV Forge ROS 2 Development Container",
     "privileged": true,
-    "features": {
-        "desktop-lite": {
-            "password": "vscode",
-            "webPort": 6080,
-            "vncPort": 5901
-        }
-    },
     "build": {
         "dockerfile": "Dockerfile"
     },
@@ -25,5 +18,5 @@
     "forwardPorts": [
         6080
     ],
-    "postCreateCommand": "echo 'source /opt/ros/foxy/setup.sh' > /root/.bashrc"
+    "postCreateCommand": "echo 'source /opt/ros/humble/setup.sh' > /root/.bashrc"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,9 @@
     "name": "UAV Forge ROS 2 Development Container",
     "privileged": true,
     "build": {
-        "dockerfile": "Dockerfile"
+        "dockerfile": "Dockerfile",
+        "context":".."
+
     },
     "workspaceFolder": "/home/ws/uavf_2024",
     "workspaceMount": "source=${localWorkspaceFolder},target=/home/ws/uavf_2024,type=bind",

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
         'scipy',
         'matplotlib',
         'casadi',
-        'ultalytics'
+        'ultralytics',
+        'coverage'
     ]
 )


### PR DESCRIPTION
Got rid of everything besides ROS2 humble and python, and made sure python stuff works out of the box. There is still one manual step, `pip install -e .` after building the dev container, but I tried putting it in the DockerFile and it didn't work, but if someone else can figure that out it'd be awesome.

Basically, now the only steps to setup and verify your local dev environment for the imaging team are:
1. clone repo
2. reopen in dev container
3. `pip install -e .`
4. `./run_tests.sh`